### PR TITLE
Compiled v3.0.2a and archived assess folder

### DIFF
--- a/v3.0.2a/v3.0.2a/pack.mcmeta
+++ b/v3.0.2a/v3.0.2a/pack.mcmeta
@@ -2,6 +2,5 @@
     "pack": {
         "pack_format": 9,
         "description": "Blu-RAE by PuppyRaeLuna"
-
     }
 }


### PR DESCRIPTION
Zipped together the pack version v3.0.2a for 1.19-1.19.2 with the correct files and archived the v3.0.2a folder that was used to assess and compare between v3.0.2 and v3.0.1 for the same MC version.